### PR TITLE
Add Claude automation workflows for issue triage and work

### DIFF
--- a/.github/workflows/claude-triage.yml
+++ b/.github/workflows/claude-triage.yml
@@ -1,0 +1,59 @@
+name: Claude Issue Triage
+
+on:
+  issues:
+    types: [opened, labeled]
+
+jobs:
+  triage:
+    # Only run for new issues with P3 label (user-reported, needs triage)
+    if: |
+      github.event.action == 'opened' ||
+      (github.event.action == 'labeled' && github.event.label.name == 'P3')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            You are triaging a new GitHub issue for the Thinkers Chat project.
+
+            REPOSITORY: ${{ github.repository }}
+            ISSUE NUMBER: #${{ github.event.issue.number }}
+            TITLE: ${{ github.event.issue.title }}
+            BODY: ${{ github.event.issue.body }}
+            AUTHOR: ${{ github.event.issue.user.login }}
+            CURRENT LABELS: ${{ join(github.event.issue.labels.*.name, ', ') }}
+
+            ## Priority Definitions
+            - P0: Blocks most or all functionality (critical bugs, system down)
+            - P1: Blocks some functionality OR new feature requests
+            - P2: Optimizations, cleanup, refactoring, minor improvements
+            - P3: Unprioritized (needs triage) - should be upgraded to P0/P1/P2
+
+            ## Your Task
+            1. Read and understand the issue
+            2. Determine the appropriate priority (P0, P1, or P2)
+            3. Determine the type (bug, feature, task)
+            4. Check if this might be a duplicate of existing issues
+            5. Update the issue with correct labels
+
+            ## Actions to Take
+            1. Remove P3 label if present and add the correct priority label
+            2. Add type label (bug, feature, or task) if not present
+            3. Add a brief comment explaining your triage decision
+
+            Use these commands:
+            - `gh issue edit ${{ github.event.issue.number }} --remove-label "P3" --add-label "P1,bug"`
+            - `gh issue comment ${{ github.event.issue.number }} --body "..."`
+            - `gh issue list` to check for duplicates
+
+          claude_args: |
+            --allowedTools "Bash(gh issue:*),Bash(gh search:*)"

--- a/.github/workflows/claude-work.yml
+++ b/.github/workflows/claude-work.yml
@@ -1,0 +1,125 @@
+name: Claude Automated Work
+
+on:
+  # Run hourly
+  schedule:
+    - cron: '0 * * * *'
+  # Allow manual triggering
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: 'Specific issue number to work on (optional)'
+        required: false
+        type: number
+
+jobs:
+  find-work:
+    runs-on: ubuntu-latest
+    outputs:
+      issue_number: ${{ steps.find.outputs.issue_number }}
+      issue_title: ${{ steps.find.outputs.issue_title }}
+    permissions:
+      issues: read
+
+    steps:
+      - name: Find highest priority issue
+        id: find
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # If specific issue provided, use that
+          if [ -n "${{ inputs.issue_number }}" ]; then
+            echo "issue_number=${{ inputs.issue_number }}" >> $GITHUB_OUTPUT
+            TITLE=$(gh issue view ${{ inputs.issue_number }} --repo ${{ github.repository }} --json title -q .title 2>/dev/null || echo "")
+            echo "issue_title=$TITLE" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Find issues by priority (P0 > P1 > P2), excluding claude-working
+          for priority in P0 P1 P2; do
+            ISSUE=$(gh issue list --repo ${{ github.repository }} \
+              --label "$priority" \
+              --state open \
+              --json number,title \
+              --jq 'map(select(.labels | map(.name) | index("claude-working") | not)) | .[0] | "\(.number)|\(.title)"' 2>/dev/null || echo "")
+
+            if [ -n "$ISSUE" ] && [ "$ISSUE" != "null|null" ]; then
+              NUMBER=$(echo "$ISSUE" | cut -d'|' -f1)
+              TITLE=$(echo "$ISSUE" | cut -d'|' -f2-)
+              echo "Found $priority issue: #$NUMBER - $TITLE"
+              echo "issue_number=$NUMBER" >> $GITHUB_OUTPUT
+              echo "issue_title=$TITLE" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+          done
+
+          echo "No open issues to work on"
+          echo "issue_number=" >> $GITHUB_OUTPUT
+
+  work-on-issue:
+    needs: find-work
+    if: needs.find-work.outputs.issue_number != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Mark issue as in-progress
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue edit ${{ needs.find-work.outputs.issue_number }} \
+            --repo ${{ github.repository }} \
+            --add-label "claude-working"
+
+      - name: Work on issue
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            You are working on issue #${{ needs.find-work.outputs.issue_number }}: ${{ needs.find-work.outputs.issue_title }}
+
+            ## Instructions
+            1. Read CLAUDE.md for project context and coding standards
+            2. Read the full issue details with: gh issue view ${{ needs.find-work.outputs.issue_number }}
+            3. Understand the codebase structure
+            4. Implement the required changes
+            5. Run tests to verify your changes work
+            6. Create a PR with your changes
+
+            ## Development Workflow
+            - Create a branch: git checkout -b claude/issue-${{ needs.find-work.outputs.issue_number }}-${{ github.run_id }}
+            - Make changes and commit with message referencing the issue
+            - Push the branch
+            - Create a PR using: gh pr create --title "..." --body "Fixes #${{ needs.find-work.outputs.issue_number }}"
+
+            ## Testing Requirements
+            - Run backend tests: cd backend && uv run pytest
+            - Run frontend tests: cd frontend && npm test
+            - Run linting: cd backend && uv run ruff check . && cd ../frontend && npm run lint
+
+            ## Important
+            - Follow existing code patterns
+            - Write tests for new functionality
+            - Keep changes minimal and focused
+            - If you encounter blockers, comment on the issue explaining what's needed
+
+          claude_args: |
+            --max-turns 50
+
+      - name: Remove in-progress label on completion
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue edit ${{ needs.find-work.outputs.issue_number }} \
+            --repo ${{ github.repository }} \
+            --remove-label "claude-working" || true


### PR DESCRIPTION
## Summary
Implements background Claude automation for automatic issue triage and work processing.

### New Workflows
- **claude-triage.yml**: Auto-triage new issues and P3 labeled issues
  - Assigns priority (P0/P1/P2) based on issue content
  - Adds type labels (bug, feature, task)
  - Comments with triage reasoning
  - Checks for duplicate issues

- **claude-work.yml**: Hourly scheduled work on open issues
  - Finds highest priority issue (P0 > P1 > P2)
  - Adds `claude-working` label while in progress
  - Implements changes, runs tests, creates PR
  - Supports manual trigger for specific issues

### Documentation
- Added "Claude Automation" section to CLAUDE.md explaining how workflows operate

## Test plan
- [ ] Verify workflows appear in GitHub Actions
- [ ] Test manual trigger of claude-work workflow
- [ ] Create a test P3 issue to verify triage workflow triggers

## Requirements
- `ANTHROPIC_API_KEY` secret must be set in repository settings

Fixes #9