### PR TITLE
Improve work workflow: event-driven + self-chaining

### DIFF
--- a/.github/workflows/claude-work.yml
+++ b/.github/workflows/claude-work.yml
@@ -1,10 +1,20 @@
 name: Claude Automated Work
 
 on:
-  # Run hourly
+  # Trigger immediately when issues get priority labels
+  issues:
+    types: [labeled]
+
+  # Self-chain: continue working after previous job completes
+  workflow_run:
+    workflows: ["Claude Automated Work"]
+    types: [completed]
+
+  # Fallback: catch edge cases (reduced frequency since event-driven)
   schedule:
-    - cron: '0 * * * *'
-  # Allow manual triggering
+    - cron: '0 */6 * * *'  # Every 6 hours
+
+  # Manual trigger
   workflow_dispatch:
     inputs:
       issue_number:
@@ -12,8 +22,51 @@ on:
         required: false
         type: number
 
+# Only one work job at a time - queue others
+concurrency:
+  group: claude-work
+  cancel-in-progress: false
+
 jobs:
+  # Gate job: check if we should run
+  should-run:
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
+    steps:
+      - name: Check trigger conditions
+        id: check
+        run: |
+          # Always run for manual triggers and schedule
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] || [ "${{ github.event_name }}" = "schedule" ]; then
+            echo "should_run=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # For workflow_run (self-chain), always check for more work
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            echo "should_run=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # For issue labeled events, only run if label is P0, P1, or P2
+          if [ "${{ github.event_name }}" = "issues" ]; then
+            LABEL="${{ github.event.label.name }}"
+            if [ "$LABEL" = "P0" ] || [ "$LABEL" = "P1" ] || [ "$LABEL" = "P2" ]; then
+              echo "Triggered by priority label: $LABEL"
+              echo "should_run=true" >> $GITHUB_OUTPUT
+            else
+              echo "Ignoring non-priority label: $LABEL"
+              echo "should_run=false" >> $GITHUB_OUTPUT
+            fi
+            exit 0
+          fi
+
+          echo "should_run=false" >> $GITHUB_OUTPUT
+
   find-work:
+    needs: should-run
+    if: needs.should-run.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     outputs:
       issue_number: ${{ steps.find.outputs.issue_number }}
@@ -40,10 +93,10 @@ jobs:
             ISSUE=$(gh issue list --repo ${{ github.repository }} \
               --label "$priority" \
               --state open \
-              --json number,title \
-              --jq 'map(select(.labels | map(.name) | index("claude-working") | not)) | .[0] | "\(.number)|\(.title)"' 2>/dev/null || echo "")
+              --json number,title,labels \
+              --jq '[.[] | select(.labels | map(.name) | index("claude-working") | not)] | .[0] | "\(.number)|\(.title)"' 2>/dev/null || echo "")
 
-            if [ -n "$ISSUE" ] && [ "$ISSUE" != "null|null" ]; then
+            if [ -n "$ISSUE" ] && [ "$ISSUE" != "null|null" ] && [ "$ISSUE" != "|" ]; then
               NUMBER=$(echo "$ISSUE" | cut -d'|' -f1)
               TITLE=$(echo "$ISSUE" | cut -d'|' -f2-)
               echo "Found $priority issue: #$NUMBER - $TITLE"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,20 +311,24 @@ Background automation handles issue triage and work without manual intervention.
 - Checks for duplicate issues
 
 **Automated Work** (`.github/workflows/claude-work.yml`):
-- Runs hourly on schedule
+- **Event-driven**: Triggers immediately when issues get P0/P1/P2 labels
+- **Self-chaining**: After completing work, automatically checks for more issues
+- **Fallback**: Scheduled every 6 hours to catch edge cases
 - Finds highest priority open issue (P0 → P1 → P2)
 - Adds `claude-working` label while in progress
 - Implements changes, runs tests, creates PR
 - Removes `claude-working` label when done
-- Can be triggered manually via workflow_dispatch
+- Concurrency control: only one work job runs at a time (others queue)
 
 ### How It Works
 
 1. User reports bug via "Report a Bug" button → Creates P3 issue
-2. Triage workflow runs → Upgrades to P0/P1/P2 with comment
-3. Work workflow runs hourly → Picks up highest priority issue
+2. Triage workflow runs → Assigns P0/P1/P2 label with comment
+3. Work workflow triggers immediately (event-driven by label)
 4. Claude implements fix → Creates PR with `Fixes #N`
-5. CI runs → PR merged → Issue auto-closes
+5. Work workflow self-chains → Picks up next issue if any
+6. CI runs → PR merged → Issue auto-closes
+7. Cycle continues until no P0-P2 issues remain
 
 ### Manual Trigger
 


### PR DESCRIPTION
## Summary
Updates the Claude automated work workflow to be event-driven with self-chaining, eliminating gaps where work could be done but isn't.

### Changes
- **Event-driven triggers**: Work starts immediately when issues get P0/P1/P2 labels
- **Self-chaining**: After completing work, workflow automatically checks for more issues
- **Reduced fallback**: Scheduled runs reduced from hourly to every 6 hours (since event-driven handles most cases)
- **Concurrency control**: Only one work job runs at a time (others queue)
- **Gate job**: Filters out non-priority label events to avoid unnecessary runs

### Behavior Flow
```
Issue gets P0/P1/P2 label → Work starts immediately
Work completes → Self-chain triggers → Next issue picked up
Queue empty → Workflow exits
New issue arrives → Event triggers work again
```

### Benefits
- No more waiting up to 1 hour for work to start
- Continuous processing of backlog without gaps
- More efficient: only runs when there's work (vs constant polling)

## Test plan
- [ ] Verify workflow triggers on P0/P1/P2 label events
- [ ] Verify workflow ignores other label events
- [ ] Verify self-chaining works when multiple issues exist
- [ ] Verify concurrency prevents parallel work jobs