### PR TITLE
Skip E2E for workflow-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
             e2e:
               - 'backend/**'
               - 'frontend/**'
-              - '.github/workflows/**'
+            # Note: workflow-only changes don't trigger e2e - app code unchanged
 
   backend:
     name: Backend Tests


### PR DESCRIPTION
## Summary
Removes `.github/workflows/**` from the E2E change detection filter.

## Why
Workflow-only changes (like updating claude-triage.yml or claude-work.yml) don't affect application code. Running E2E tests for these changes is:
- Wasteful (3+ minutes of CI time)
- Misleading (tests app code that hasn't changed)
- Potentially blocks deploys unnecessarily

## After this change
- Backend/frontend code changes → E2E runs
- Workflow-only changes → E2E skipped (no app code changed)

## Test plan
This PR itself is the test - it should skip E2E since only ci.yml changed.