### PR TITLE
Add --dangerously-skip-permissions to work workflow

### DIFF
--- a/.github/workflows/claude-work.yml
+++ b/.github/workflows/claude-work.yml
@@ -203,6 +203,7 @@ jobs:
 
           claude_args: |
             --max-turns 50
+            --dangerously-skip-permissions
 
       - name: Comment - Work completed
         if: success()


### PR DESCRIPTION
## Summary
- Adds `--dangerously-skip-permissions` flag to Claude in the automated work workflow
- This allows Claude to use all tools (bash, git, gh, etc.) without approval prompts
- Safe since this runs in a trusted CI environment with limited scope

## Test plan
- [ ] Workflow runs without permission denials
- [ ] Claude can execute gh commands, git commands, and development tools