### PR TITLE
Enable track_progress for work workflow visibility

### DIFF
--- a/.github/workflows/claude-work.yml
+++ b/.github/workflows/claude-work.yml
@@ -173,6 +173,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          track_progress: true
           prompt: |
             You are working on issue #${{ needs.find-work.outputs.issue_number }}: ${{ needs.find-work.outputs.issue_title }}
 


### PR DESCRIPTION
## Summary
- Adds `track_progress: true` to the Claude work workflow
- This should provide intermediate progress updates during long-running work

## Test plan
- [ ] Next workflow run shows progress updates
- [ ] Updates appear on the issue or PR as Claude works