### PR TITLE
Have Claude post its own status comments

### DIFF
--- a/.github/workflows/claude-work.yml
+++ b/.github/workflows/claude-work.yml
@@ -151,23 +151,6 @@ jobs:
             --repo ${{ github.repository }} \
             --add-label "claude-working"
 
-      - name: Comment - Starting work
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh issue comment ${{ needs.find-work.outputs.issue_number }} \
-            --repo ${{ github.repository }} \
-            --body "$(cat <<'EOF'
-          ## 🤖 Claude is working on this issue
-
-          **Status:** Starting automated work
-
-          **Workflow Run:** [View progress](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-
-          I'll analyze the issue, implement a fix, run tests, and create a PR. Updates will be posted here.
-          EOF
-          )"
-
       - name: Work on issue
         id: claude
         uses: anthropics/claude-code-action@v1
@@ -202,47 +185,14 @@ jobs:
             - Keep changes minimal and focused
             - If you encounter blockers, comment on the issue explaining what's needed
 
+            ## Status Comments (IMPORTANT)
+            Post status updates to the issue using `gh issue comment ${{ needs.find-work.outputs.issue_number }} --body "..."`:
+            1. **Before starting**: Post "🤖 Starting work on this issue. [View workflow progress](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+            2. **After creating PR**: Post "✅ Created PR: <PR_URL>. Ready for review."
+
           claude_args: |
             --max-turns 50
             --dangerously-skip-permissions
-
-      - name: Comment - Work completed
-        if: success()
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          # Check if a PR was created for this issue
-          PR_URL=$(gh pr list --repo ${{ github.repository }} \
-            --search "Fixes #${{ needs.find-work.outputs.issue_number }}" \
-            --json url --jq '.[0].url' 2>/dev/null || echo "")
-
-          if [ -n "$PR_URL" ]; then
-            gh issue comment ${{ needs.find-work.outputs.issue_number }} \
-              --repo ${{ github.repository }} \
-              --body "$(cat <<EOF
-          ## ✅ Claude completed work
-
-          **Status:** Work completed successfully
-
-          **Pull Request:** $PR_URL
-
-          The PR is ready for review. Once CI passes and it's approved, it can be merged to close this issue.
-          EOF
-          )"
-          else
-            gh issue comment ${{ needs.find-work.outputs.issue_number }} \
-              --repo ${{ github.repository }} \
-              --body "$(cat <<'EOF'
-          ## ✅ Claude completed work
-
-          **Status:** Work completed
-
-          **Workflow Run:** [View details](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-
-          Check the workflow run for details on what was done.
-          EOF
-          )"
-          fi
 
       - name: Comment - Work failed
         if: failure()


### PR DESCRIPTION
## Summary
- Removes workflow shell steps for "starting" and "completed" comments
- Adds prompt instructions for Claude to post status updates itself
- Keeps "Work failed" step as safety net (in case Claude crashes)
- All Claude comments now show `claude[bot]` icon consistently

## Changes
- Removed "Comment - Starting work" step
- Removed "Comment - Work completed" step
- Added "Status Comments" section to Claude's prompt

## Test plan
- [ ] Next workflow run shows claude[bot] icon on all comments
- [ ] Starting and completion comments still appear