### PR TITLE
Skip workflow entirely for non-priority labels

### DIFF
--- a/.github/workflows/claude-work.yml
+++ b/.github/workflows/claude-work.yml
@@ -28,7 +28,9 @@ concurrency:
 
 jobs:
   # Gate job: check if we should run
+  # Skip entirely for non-priority label events to avoid queuing
   should-run:
+    if: github.event_name != 'issues' || github.event.label.name == 'P0' || github.event.label.name == 'P1' || github.event.label.name == 'P2'
     runs-on: ubuntu-latest
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}


### PR DESCRIPTION
## Summary
- Adds `if` condition to skip the workflow entirely for non-P0/P1/P2 label events
- Prevents P3 labels from triggering runs that take up queue slots
- Fixes issue where P3-triggered runs could block legitimate P1/P2 runs

## Changes
- Added job-level `if` condition: `github.event_name != 'issues' || github.event.label.name == 'P0/P1/P2'`