### PR TITLE
Fix infinite workflow loop and enable self-chaining

### DIFF
--- a/.github/workflows/claude-work.yml
+++ b/.github/workflows/claude-work.yml
@@ -159,6 +159,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
+          allowed_bots: '*'  # Allow self-chaining via repository_dispatch
           prompt: |
             You are working on issue #${{ needs.find-work.outputs.issue_number }}: ${{ needs.find-work.outputs.issue_title }}
 
@@ -224,9 +225,10 @@ jobs:
             --remove-label "claude-working" || true
 
   # Self-chain: trigger another run if there's more work
+  # IMPORTANT: Only chain on SUCCESS to prevent infinite failure loops
   continue-work:
     needs: [find-work, work-on-issue]
-    if: always() && needs.find-work.outputs.has_more_work == 'true'
+    if: success() && needs.find-work.outputs.has_more_work == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- Fixes infinite failure loop when `work-on-issue` step fails
- Enables self-chaining for automated work queue processing

## Changes
- Change `continue-work` job from `always()` to `success()` - prevents infinite loops
- Add `allowed_bots: '*'` to claude-code-action - allows repository_dispatch self-chaining

## Problem
When `work-on-issue` failed (e.g., due to non-human actor), the `continue-work` job still ran because it used `if: always()`. This triggered another `repository_dispatch`, which also failed, creating an infinite loop of failing workflow runs.

## Testing
- Observed 4+ rapid failure runs before catching the issue
- Cancelled queued runs manually
- This fix prevents the loop by only chaining on success