### PR TITLE
Fix track_progress for non-issue events

### DIFF
--- a/.github/workflows/claude-work.yml
+++ b/.github/workflows/claude-work.yml
@@ -158,7 +158,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          track_progress: true
+          track_progress: ${{ github.event_name == 'issues' }}  # Only supported for issue events
           allowed_bots: '*'  # Allow self-chaining via repository_dispatch
           prompt: |
             You are working on issue #${{ needs.find-work.outputs.issue_number }}: ${{ needs.find-work.outputs.issue_title }}


### PR DESCRIPTION
## Summary
- Fix `track_progress` error for `repository_dispatch` and other non-issue events

## Problem
The workflow was failing with:
```
Error: Prepare step failed with error: track_progress is only supported for events: 
pull_request, issues, issue_comment, pull_request_review_comment, pull_request_review. 
Current event: repository_dispatch
```

## Solution
Make `track_progress` conditional: `${{ github.event_name == 'issues' }}`

This enables progress tracking only for issue events (which is supported) and disables it for repository_dispatch, schedule, and workflow_dispatch events.