### PR TITLE
Fix work queue to continue processing after failures

### DIFF
--- a/.github/workflows/claude-work.yml
+++ b/.github/workflows/claude-work.yml
@@ -216,7 +216,10 @@ jobs:
           )"
 
       - name: Remove in-progress label on completion
-        if: always()
+        # Only remove on SUCCESS - failed issues keep the label so they're skipped
+        # in the next run (prevents same issue from failing repeatedly)
+        # The label will be removed when: PR merges (issue closes) or human intervenes
+        if: success()
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -225,10 +228,11 @@ jobs:
             --remove-label "claude-working" || true
 
   # Self-chain: trigger another run if there's more work
-  # IMPORTANT: Only chain on SUCCESS to prevent infinite failure loops
+  # Runs on always() so failures don't stop the queue - other issues still get processed
+  # Failed issues keep claude-working label, so they're skipped (prevents infinite loops)
   continue-work:
     needs: [find-work, work-on-issue]
-    if: success() && needs.find-work.outputs.has_more_work == 'true'
+    if: always() && needs.find-work.outputs.has_more_work == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
Fixes the issue where a failed job would stop the entire work queue, leaving other issues unprocessed.

## Problem
When Claude's work on an issue failed (e.g., max turns), the `continue-work` job didn't run because it required `success()`. This meant:
- Other P0/P1/P2 issues were left waiting
- Only the 6-hour schedule fallback would pick them up

## Solution

| Component | Before | After |
|-----------|--------|-------|
| `continue-work` condition | `success()` | `always()` |
| Remove `claude-working` label | `always()` | `success()` |

### How it works now:

```
Issue A (P1) fails with max-turns
    ↓
claude-working label KEPT on issue A
    ↓
continue-work runs (always())
    ↓
find-work excludes A (has claude-working label)
    ↓
Picks up Issue B (P2) instead
    ↓
Meanwhile, Issue A's PR goes through CI/CD fix workflow
    ↓
PR merges → Issue A closes → label irrelevant
```

### Prevents infinite loops:
- Failed issues keep `claude-working` label
- `find-work` excludes issues with that label
- Same issue won't be retried immediately
- CI/CD fix workflow handles the failing PR separately