### PR TITLE
Add auto-merge to complete the automation pipeline

### DIFF
--- a/.github/workflows/claude-work.yml
+++ b/.github/workflows/claude-work.yml
@@ -176,6 +176,7 @@ jobs:
             - Make changes and commit with message referencing the issue
             - Push the branch
             - Create a PR using: gh pr create --title "..." --body "Fixes #${{ needs.find-work.outputs.issue_number }}"
+            - Enable auto-merge: gh pr merge --auto --squash (this merges automatically when CI passes)
 
             ## Testing Requirements
             - Run backend tests: cd backend && uv run pytest
@@ -191,7 +192,7 @@ jobs:
             ## Status Comments (IMPORTANT)
             Post status updates to the issue using `gh issue comment ${{ needs.find-work.outputs.issue_number }} --body "..."`:
             1. **Before starting**: Post "🤖 Starting work on this issue. [View workflow progress](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
-            2. **After creating PR**: Post "✅ Created PR: <PR_URL>. Ready for review."
+            2. **After creating PR with auto-merge**: Post "✅ Created PR: <PR_URL>. Auto-merge enabled - will merge when CI passes."
 
           claude_args: |
             --max-turns 50

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -318,8 +318,9 @@ Background automation handles issue triage and work without manual intervention.
 - Finds highest priority open issue (P0 → P1 → P2)
 - Adds `claude-working` label while in progress
 - **Status comments**: Posts updates to issue when starting and completing work
-- Implements changes, runs tests, creates PR
-- Removes `claude-working` label when done
+- Implements changes, runs tests, creates PR with **auto-merge enabled**
+- PRs merge automatically when CI passes (no manual intervention needed)
+- Removes `claude-working` label when done (on success only - failed issues keep label)
 - Concurrency control: only one work job runs at a time (others queue)
 
 **CI/CD Fix Loop** (`.github/workflows/claude-cicd-fix.yml`):
@@ -335,7 +336,7 @@ Background automation handles issue triage and work without manual intervention.
 1. User reports bug via "Report a Bug" button → Creates P3 issue
 2. Triage workflow runs → Assigns P0/P1/P2 label with comment
 3. Work workflow triggers immediately (event-driven by label)
-4. Claude implements fix → Creates PR with `Fixes #N`
+4. Claude implements fix → Creates PR with `Fixes #N` + enables auto-merge
 5. CI/CD runs on PR
 6. **If CI/CD fails**: CI/CD Fix workflow triggers
    - Analyzes failure logs


### PR DESCRIPTION
## Summary
Adds auto-merge instruction so PRs created by Claude automatically merge when CI passes.

## Changes
- Updated workflow prompt to instruct Claude to run `gh pr merge --auto --squash`
- Updated status comment to say "Auto-merge enabled"
- Updated CLAUDE.md documentation

## Result
The pipeline is now fully automated:
1. User reports bug → Issue created
2. Triage → Priority assigned  
3. Claude works → PR created with auto-merge
4. CI passes → **PR merges automatically**
5. Issue closes → Next issue picked up

No manual intervention needed!