### PR TITLE
Fix: Remove redundant Cancel button from NewChatModal

### DIFF
--- a/frontend/src/__tests__/components/NewChatModal.test.tsx
+++ b/frontend/src/__tests__/components/NewChatModal.test.tsx
@@ -53,14 +53,6 @@ describe('NewChatModal', () => {
     expect(onClose).toHaveBeenCalled();
   });
 
-  it('calls onClose when cancel button is clicked', () => {
-    const onClose = jest.fn();
-    render(<NewChatModal {...defaultProps} onClose={onClose} />);
-
-    fireEvent.click(screen.getByText('Cancel'));
-    expect(onClose).toHaveBeenCalled();
-  });
-
   it('calls onClose when clicking outside modal', () => {
     const onClose = jest.fn();
     render(<NewChatModal {...defaultProps} onClose={onClose} />);

--- a/frontend/src/components/NewChatModal.tsx
+++ b/frontend/src/components/NewChatModal.tsx
@@ -317,12 +317,6 @@ export function NewChatModal({
             </button>
           )}
           <div className="flex gap-2 ml-auto">
-            <button
-              onClick={onClose}
-              className="px-4 py-2 text-zinc-700 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-800 rounded-lg transition-colors"
-            >
-              Cancel
-            </button>
             {step === 'topic' ? (
               <button
                 onClick={(e) => handleTopicSubmit(e as unknown as FormEvent)}


### PR DESCRIPTION
## Summary
Removed the redundant Cancel button from the NewChatModal footer, keeping only the X button in the header for dismissal. This follows conventional modal UI patterns for simple modals.

## Changes
- Removed Cancel button from modal footer (`frontend/src/components/NewChatModal.tsx`)
- Updated tests - removed test for Cancel button click (`frontend/src/__tests__/components/NewChatModal.test.tsx`)

## Test Results
- All 15 test suites pass (162 tests)
- Linting clean

Fixes #44

Generated with [Claude Code](https://claude.ai/code)