### PR TITLE
Fix: Add allowed_tools for gh and test commands in Claude workflows

### DIFF
--- a/.github/workflows/claude-cicd-fix.yml
+++ b/.github/workflows/claude-cicd-fix.yml
@@ -216,6 +216,10 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_bots: '*'
+          allowed_tools: |
+            Edit,MultiEdit,Glob,Grep,LS,Read,Write
+            Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*)
+            Bash(cd backend && uv run:*),Bash(cd frontend && npm:*)
           prompt: |
             ## CI/CD Fix Required - Attempt ${{ steps.count-retries.outputs.next_retry }} of ${{ env.MAX_RETRIES }}
 

--- a/.github/workflows/claude-work.yml
+++ b/.github/workflows/claude-work.yml
@@ -160,6 +160,11 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: ${{ github.event_name == 'issues' }}  # Only supported for issue events
           allowed_bots: '*'  # Allow self-chaining via repository_dispatch
+          allowed_tools: |
+            Edit,MultiEdit,Glob,Grep,LS,Read,Write
+            Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git rm:*)
+            Bash(gh pr create:*),Bash(gh pr merge:*),Bash(gh pr view:*),Bash(gh issue view:*),Bash(gh issue comment:*)
+            Bash(cd backend && uv run pytest:*),Bash(cd frontend && npm test:*),Bash(cd backend && uv run ruff check:*),Bash(cd frontend && npm run lint:*)
           prompt: |
             You are working on issue #${{ needs.find-work.outputs.issue_number }}: ${{ needs.find-work.outputs.issue_title }}
 


### PR DESCRIPTION
## Summary
Fixed the issue where Claude worker couldn't create PRs with auto-merge because the required tools weren't whitelisted.

## Problem
The Claude Code Action only allows specific tools by default. The claude-work workflow was instructing Claude to run `gh pr create` and `gh pr merge --auto --squash`, but these commands weren't in the allowed_tools list. This caused Claude to only push to a branch and provide a "Create PR" link instead of actually creating the PR.

## Solution
Added `allowed_tools` configuration to both workflows:

**claude-work.yml:**
- Added gh commands: `gh pr create`, `gh pr merge`, `gh pr view`, `gh issue view`, `gh issue comment`
- Added test commands: backend pytest, frontend npm test, ruff check, npm run lint

**claude-cicd-fix.yml:**
- Added backend/frontend test commands for validation

## Test Plan
- Workflow changes should enable Claude to run `gh pr create --title "..." --body "..."` and `gh pr merge --auto --squash`
- Next automated issue should create a PR automatically

Relates to #44