### PR TITLE
Fix CI/CD: Format files missed by PR #48

### DIFF
--- a/frontend/src/__tests__/middleware.test.ts
+++ b/frontend/src/__tests__/middleware.test.ts
@@ -21,7 +21,8 @@ describe('Cache Control Middleware', () => {
 
   it('should document expected cache behavior for HTML pages', () => {
     // Documentation test: HTML pages should not be cached
-    const expectedCacheControl = 'no-cache, no-store, must-revalidate, max-age=0';
+    const expectedCacheControl =
+      'no-cache, no-store, must-revalidate, max-age=0';
     expect(expectedCacheControl).toContain('no-cache');
   });
 

--- a/frontend/src/components/__tests__/BuildInfo.test.tsx
+++ b/frontend/src/components/__tests__/BuildInfo.test.tsx
@@ -28,7 +28,9 @@ describe('BuildInfo', () => {
     render(<BuildInfo />);
 
     expect(consoleLogSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Thinkers Chat - Build: 2025-12-18T08:00:00.000Z'),
+      expect.stringContaining(
+        'Thinkers Chat - Build: 2025-12-18T08:00:00.000Z'
+      ),
       expect.any(String)
     );
 

--- a/frontend/src/lib/version.ts
+++ b/frontend/src/lib/version.ts
@@ -5,7 +5,9 @@
 // Read version from package.json at build time
 // This will be embedded in the bundle
 export const APP_VERSION =
-  process.env.NEXT_PUBLIC_APP_VERSION || process.env.npm_package_version || '0.1.0';
+  process.env.NEXT_PUBLIC_APP_VERSION ||
+  process.env.npm_package_version ||
+  '0.1.0';
 
 // Generate a build timestamp that changes with each build
 export const BUILD_TIMESTAMP = Date.now().toString();


### PR DESCRIPTION
## Summary
Fixes formatting issues that broke CI after PR #48 merged.

## Failing check
Frontend Tests - Format check

## Error
Code style issues found in 3 files:
- `src/__tests__/middleware.test.ts`
- `src/components/__tests__/BuildInfo.test.tsx`
- `src/lib/version.ts`

## Fix
Ran `npm run format` to apply prettier formatting.