### PR TITLE
Fix: Remove invalid allowed_tools input from workflows

### DIFF
--- a/.github/workflows/claude-cicd-fix.yml
+++ b/.github/workflows/claude-cicd-fix.yml
@@ -216,10 +216,6 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_bots: '*'
-          allowed_tools: |
-            Edit,MultiEdit,Glob,Grep,LS,Read,Write
-            Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*)
-            Bash(cd backend && uv run:*),Bash(cd frontend && npm:*)
           prompt: |
             ## CI/CD Fix Required - Attempt ${{ steps.count-retries.outputs.next_retry }} of ${{ env.MAX_RETRIES }}
 

--- a/.github/workflows/claude-work.yml
+++ b/.github/workflows/claude-work.yml
@@ -160,11 +160,6 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: ${{ github.event_name == 'issues' }}  # Only supported for issue events
           allowed_bots: '*'  # Allow self-chaining via repository_dispatch
-          allowed_tools: |
-            Edit,MultiEdit,Glob,Grep,LS,Read,Write
-            Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git rm:*)
-            Bash(gh pr create:*),Bash(gh pr merge:*),Bash(gh pr view:*),Bash(gh issue view:*),Bash(gh issue comment:*)
-            Bash(cd backend && uv run pytest:*),Bash(cd frontend && npm test:*),Bash(cd backend && uv run ruff check:*),Bash(cd frontend && npm run lint:*)
           prompt: |
             You are working on issue #${{ needs.find-work.outputs.issue_number }}: ${{ needs.find-work.outputs.issue_title }}
 


### PR DESCRIPTION
## Summary
Removes the invalid `allowed_tools` input parameter from both workflow files.

## Problem
The workflows had both:
- `allowed_tools:` input (invalid, causes warning)
- `--allowedTools` in `claude_args` (correct)

The invalid parameter was being ignored with a warning but cluttering logs.

## Changes
- `.github/workflows/claude-work.yml` - Removed invalid `allowed_tools` input
- `.github/workflows/claude-cicd-fix.yml` - Removed invalid `allowed_tools` input

The `--allowedTools` in `claude_args` remains and is the correct way to configure tools.