### PR TITLE
Add claude-triaging label to distinguish from claude-working

### DIFF
--- a/.github/workflows/claude-triage.yml
+++ b/.github/workflows/claude-triage.yml
@@ -22,6 +22,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Mark issue as being triaged
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue edit ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --add-label "claude-triaging"
+
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -68,3 +76,12 @@ jobs:
           claude_args: |
             --dangerously-skip-permissions
             --allowedTools "Bash(gh issue:*),Bash(gh search:*)"
+
+      - name: Remove triaging label
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue edit ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --remove-label "claude-triaging" || true


### PR DESCRIPTION
## Summary
- Adds `claude-triaging` label when triage workflow starts on an issue
- Removes the label when triage completes (using `if: always()` to ensure cleanup)

This distinguishes between:
- **claude-triaging**: Issue is being analyzed for priority/type
- **claude-working**: Issue is being implemented/fixed

Provides better visibility into what Claude is actively doing.

## Test plan
- [ ] File a new issue via the app
- [ ] Verify `claude-triaging` label appears during triage
- [ ] Verify label is removed after triage completes
- [ ] Verify `claude-working` only appears during actual work