### PR TITLE
Add automatic issue breakdown for complex issues

### DIFF
--- a/.github/workflows/claude-breakdown.yml
+++ b/.github/workflows/claude-breakdown.yml
@@ -1,0 +1,145 @@
+name: Claude Issue Breakdown
+
+# Automatically break down complex issues that exceeded max-turns into smaller sub-tasks
+
+on:
+  # Triggered by work workflow when max-turns is hit
+  repository_dispatch:
+    types: [claude-breakdown-needed]
+
+  # Manual trigger for testing
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: 'Issue number to break down'
+        required: true
+        type: number
+
+jobs:
+  breakdown:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get issue details
+        id: issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            ISSUE_NUMBER="${{ inputs.issue_number }}"
+          else
+            ISSUE_NUMBER="${{ github.event.client_payload.issue_number }}"
+          fi
+
+          echo "issue_number=$ISSUE_NUMBER" >> $GITHUB_OUTPUT
+
+          # Get issue details
+          ISSUE_DATA=$(gh api repos/${{ github.repository }}/issues/$ISSUE_NUMBER)
+          ISSUE_TITLE=$(echo "$ISSUE_DATA" | jq -r '.title')
+          ISSUE_BODY=$(echo "$ISSUE_DATA" | jq -r '.body')
+          ISSUE_LABELS=$(echo "$ISSUE_DATA" | jq -r '[.labels[].name] | join(",")')
+
+          echo "issue_title=$ISSUE_TITLE" >> $GITHUB_OUTPUT
+
+          # Save body to file (may be long)
+          echo "$ISSUE_BODY" > /tmp/issue_body.txt
+
+      - name: Mark issue as being broken down
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue edit ${{ steps.issue.outputs.issue_number }} \
+            --repo ${{ github.repository }} \
+            --add-label "breaking-down" \
+            --remove-label "needs-human-help" || true
+
+      - name: Break down issue with Claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            ## Task: Break Down Complex Issue
+
+            Issue #${{ steps.issue.outputs.issue_number }} exceeded the 50-turn limit, indicating it's too complex for a single automated run. Your job is to break it into smaller, manageable sub-tasks.
+
+            ### Original Issue
+            **Title:** ${{ steps.issue.outputs.issue_title }}
+            **Body:**
+            $(cat /tmp/issue_body.txt)
+
+            ### Instructions
+
+            1. **Analyze the issue** - Understand what's being requested
+            2. **Identify natural sub-tasks** - Break it into 3-6 smaller pieces that can each be done in ~20 turns
+            3. **Create sub-issues** - Each should be:
+               - Self-contained and independently testable
+               - Clearly scoped with specific acceptance criteria
+               - Ordered by dependency (what needs to be done first)
+
+            ### Creating Sub-Issues
+
+            Use this format for each sub-issue:
+            ```bash
+            gh issue create \
+              --repo ${{ github.repository }} \
+              --title "Sub-task: <specific task>" \
+              --label "P1,task" \
+              --body "## Parent Issue
+            Part of #${{ steps.issue.outputs.issue_number }}
+
+            ## Description
+            <what needs to be done>
+
+            ## Acceptance Criteria
+            - [ ] <criterion 1>
+            - [ ] <criterion 2>
+
+            ## Dependencies
+            <any sub-tasks that must be done first, or 'None'>"
+            ```
+
+            ### After Creating Sub-Issues
+
+            1. Comment on the parent issue listing all created sub-issues:
+            ```bash
+            gh issue comment ${{ steps.issue.outputs.issue_number }} --body "## Issue Breakdown
+
+            This issue has been broken down into smaller sub-tasks:
+
+            - #<num1> - <title1>
+            - #<num2> - <title2>
+            ...
+
+            The parent issue will be closed when all sub-tasks are complete."
+            ```
+
+            2. Add the 'epic' label to the parent issue and remove priority labels (sub-issues have their own priorities):
+            ```bash
+            gh issue edit ${{ steps.issue.outputs.issue_number }} --add-label "epic" --remove-label "P0,P1,P2,P3"
+            ```
+
+            ### Guidelines
+            - Each sub-task should be small enough to complete in one automated run
+            - Order sub-tasks by dependency - infrastructure/schema first, then backend, then frontend
+            - Keep acceptance criteria specific and testable
+            - Don't over-engineer - keep scope minimal
+
+          claude_args: |
+            --max-turns 30
+            --dangerously-skip-permissions
+            --allowedTools "Bash(gh issue:*),Bash(gh search:*)"
+
+      - name: Cleanup labels
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue edit ${{ steps.issue.outputs.issue_number }} \
+            --repo ${{ github.repository }} \
+            --remove-label "breaking-down" || true

--- a/.github/workflows/claude-work.yml
+++ b/.github/workflows/claude-work.yml
@@ -87,7 +87,10 @@ jobs:
             exit 0
           fi
 
-          # Find all issues by priority (P0 > P1 > P2), excluding claude-working
+          # Find all issues by priority (P0 > P1 > P2), excluding:
+          # - claude-working: currently being worked on
+          # - needs-human-help: blocked, needs human intervention
+          # - epic: parent issue broken into sub-tasks
           FOUND_COUNT=0
           FOUND_NUMBER=""
           FOUND_TITLE=""
@@ -97,7 +100,7 @@ jobs:
               --label "$priority" \
               --state open \
               --json number,title,labels \
-              --jq '[.[] | select(.labels | map(.name) | index("claude-working") | not)]' 2>/dev/null || echo "[]")
+              --jq '[.[] | select(.labels | map(.name) | (index("claude-working") | not) and (index("needs-human-help") | not) and (index("epic") | not))]' 2>/dev/null || echo "[]")
 
             COUNT=$(echo "$ISSUES" | jq 'length')
 
@@ -199,8 +202,55 @@ jobs:
             --dangerously-skip-permissions
             --allowedTools "Edit,MultiEdit,Glob,Grep,LS,Read,Write,Bash(git:*),Bash(gh:*),Bash(cd backend && uv run:*),Bash(cd frontend && npm:*)"
 
-      - name: Mark as needing human help and notify
+      - name: Check failure type and handle appropriately
         if: failure()
+        id: check-failure
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Check if this was a max-turns failure (issue too complex)
+          # The claude-code-action saves output with "error_max_turns" subtype
+          LOG_FILE="${RUNNER_TEMP}/claude-execution-output.json"
+
+          if [ -f "$LOG_FILE" ] && grep -q "error_max_turns" "$LOG_FILE"; then
+            echo "max_turns_exceeded=true" >> $GITHUB_OUTPUT
+            echo "Detected max-turns failure - will trigger breakdown"
+          else
+            echo "max_turns_exceeded=false" >> $GITHUB_OUTPUT
+            echo "Other failure type - will request human help"
+          fi
+
+      - name: Trigger breakdown for complex issues
+        if: failure() && steps.check-failure.outputs.max_turns_exceeded == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Remove claude-working label so issue isn't stuck
+          gh issue edit ${{ needs.find-work.outputs.issue_number }} \
+            --repo ${{ github.repository }} \
+            --remove-label "claude-working" || true
+
+          # Comment about breakdown
+          gh issue comment ${{ needs.find-work.outputs.issue_number }} \
+            --repo ${{ github.repository }} \
+            --body "$(cat <<'EOF'
+          ## 🔄 Issue Too Complex - Breaking Down
+
+          This issue exceeded the 50-turn limit, indicating it's too complex for a single automated run.
+
+          **Triggering automatic breakdown** into smaller sub-tasks...
+
+          [View workflow progress](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          EOF
+          )"
+
+          # Trigger breakdown workflow
+          gh api repos/${{ github.repository }}/dispatches \
+            -f event_type=claude-breakdown-needed \
+            -f 'client_payload[issue_number]=${{ needs.find-work.outputs.issue_number }}'
+
+      - name: Mark as needing human help for other failures
+        if: failure() && steps.check-failure.outputs.max_turns_exceeded != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
## Summary
- Create `claude-breakdown.yml` workflow that breaks complex issues into sub-tasks
- Detect max-turns failures and trigger breakdown instead of just failing
- Skip issues with `needs-human-help` or `epic` labels when finding work
- Add `epic` and `breaking-down` labels for visibility

## How It Works
When an issue exceeds 50 turns, Claude now automatically:
1. Comments that the issue will be broken down
2. Triggers the breakdown workflow
3. Creates smaller sub-issues that can each be completed in one run
4. Marks the parent as an 'epic'

This prevents complex issues from blocking the work queue.

## Queue Improvements
- Issues with `needs-human-help` are now skipped (queue continues)
- Issues with `epic` label are skipped (work on sub-issues instead)

## Test plan
- [ ] Manually trigger breakdown on issue #55 to test
- [ ] Verify sub-issues are created with proper links
- [ ] Verify parent issue gets `epic` label
- [ ] Verify work queue continues past blocked issues