### PR TITLE
Add spend limit enforcement for users

### DIFF
--- a/backend/alembic/versions/c1a2b3d4e5f6_add_spend_limit_to_users.py
+++ b/backend/alembic/versions/c1a2b3d4e5f6_add_spend_limit_to_users.py
@@ -1,0 +1,32 @@
+"""Add spend_limit to users
+
+Revision ID: c1a2b3d4e5f6
+Revises: 815724a57297
+Create Date: 2025-12-18
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c1a2b3d4e5f6"
+down_revision: str | Sequence[str] | None = "815724a57297"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add spend_limit column to users table."""
+    op.add_column(
+        "users",
+        sa.Column("spend_limit", sa.Float, nullable=False, server_default="10.0"),
+    )
+
+
+def downgrade() -> None:
+    """Remove spend_limit column from users table."""
+    op.drop_column("users", "spend_limit")

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -45,6 +45,11 @@ class User(Base, TimestampMixin):
         default=0.0,
         nullable=False,
     )
+    spend_limit: Mapped[float] = mapped_column(
+        Float,
+        default=10.0,  # Default $10 limit per user
+        nullable=False,
+    )
     display_name: Mapped[str | None] = mapped_column(
         String(100),
         nullable=True,


### PR DESCRIPTION
## Summary
Implements a simplified spend limit system that enforces spending limits per user without requiring the complex multi-table schema proposed in #61.

## Changes
- **User model**: Add `spend_limit` field (default $10)
- **Database migration**: New alembic migration for spend_limit column
- **Spend service**: Add `check_spend_limit()` and `can_user_spend()` utilities
- **WebSocket handler**: Check limits before saving messages, raise `SpendLimitExceeded` when exceeded
- **Thinker service**: Catch spend limit errors, pause conversation, notify user via WebSocket

## How it works
1. Each user has a `spend_limit` field (default $10)
2. Before saving any thinker message, the system checks if `total_spend >= spend_limit`
3. If over limit: raises `SpendLimitExceeded` exception
4. The thinker agent catches this, pauses the conversation, and sends an error message to the user
5. User must contact admin to increase their limit

## Test Plan
- [x] All 14 spend service tests pass
- [x] All 105 backend tests pass
- [x] Linting and type checking pass
- [x] Added tests for spend limit checking:
  - User not found
  - Under limit
  - At limit
  - Over limit
  - Near limit (85%)
  - can_user_spend scenarios

## Related Issues
- Fixes #63 (Add spend limit enforcement)
- Fixes #74 (Create spend limit checking utility)
- Relates to #61, #75, #76, #77, #78 (can be closed as simplified approach)