### PR TITLE
Fix lint errors blocking deployment

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -63,7 +63,10 @@ app = FastAPI(
 
 # Exception handler for BillingError
 @app.exception_handler(BillingError)
-async def billing_error_handler(request: Request, exc: BillingError) -> JSONResponse:
+async def billing_error_handler(
+    request: Request,  # noqa: ARG001 - FastAPI requires this parameter
+    exc: BillingError,
+) -> JSONResponse:
     """Handle BillingError exceptions by returning 503 Service Unavailable.
 
     When a BillingError occurs (e.g., quota exceeded, billing issues):

--- a/backend/tests/test_trigger_error_endpoint.py
+++ b/backend/tests/test_trigger_error_endpoint.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import (
     create_async_engine,
 )
 
-from app.api.websocket import ConnectionManager, WSMessage, WSMessageType
+from app.api.websocket import WSMessage, WSMessageType
 from app.core.database import get_db
 from app.main import app
 from app.models import Base


### PR DESCRIPTION
## Summary
- Add noqa comment for unused request param in billing_error_handler (required by FastAPI)
- Remove unused ConnectionManager import from test file

## Urgent
PR #194 merged with lint errors, blocking deployment. This fixes main so deploys can proceed.