### PR TITLE
Fix workflow: close issues only after successful deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,3 +369,59 @@ jobs:
             echo "Auth check failed with status: $http_code"
             exit 1
           fi
+
+  # Close issues only after successful deploy and smoke tests
+  close-issues:
+    name: Close Related Issues
+    runs-on: ubuntu-latest
+    needs: [smoke-test]
+    if: |
+      always() &&
+      needs.smoke-test.result == 'success' &&
+      github.ref == 'refs/heads/main' &&
+      github.event_name == 'push'
+    permissions:
+      issues: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 10  # Get recent commits to find issue references
+
+      - name: Find and close related issues
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "Finding issues referenced in recent commits..."
+
+          # Get issue numbers from commit messages (looks for "Relates to #N" or "#N")
+          ISSUE_NUMBERS=$(git log --oneline -10 | grep -oE '#[0-9]+' | tr -d '#' | sort -u)
+
+          if [ -z "$ISSUE_NUMBERS" ]; then
+            echo "No issue references found in recent commits"
+            exit 0
+          fi
+
+          echo "Found issue references: $ISSUE_NUMBERS"
+
+          for ISSUE_NUM in $ISSUE_NUMBERS; do
+            echo "Checking issue #$ISSUE_NUM..."
+
+            # Get issue state
+            STATE=$(gh issue view $ISSUE_NUM --json state -q .state 2>/dev/null || echo "NOT_FOUND")
+
+            if [ "$STATE" = "OPEN" ]; then
+              echo "Closing issue #$ISSUE_NUM (deploy successful)"
+              gh issue close $ISSUE_NUM \
+                --comment "✅ **Deployed to production**
+
+              This issue was resolved and the fix has been successfully deployed.
+
+              Commit: ${{ github.sha }}
+              Workflow: [View run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+            elif [ "$STATE" = "CLOSED" ]; then
+              echo "Issue #$ISSUE_NUM already closed"
+            else
+              echo "Issue #$ISSUE_NUM not found or inaccessible"
+            fi
+          done

--- a/.github/workflows/claude-work.yml
+++ b/.github/workflows/claude-work.yml
@@ -251,7 +251,7 @@ jobs:
             - Create a branch: git checkout -b claude/issue-${{ needs.find-work.outputs.issue_number }}-${{ github.run_id }}
             - Make changes and commit with message referencing the issue
             - Push the branch
-            - Create a PR using: gh pr create --title "..." --body "Fixes #${{ needs.find-work.outputs.issue_number }}"
+            - Create a PR using: gh pr create --title "..." --body "Relates to #${{ needs.find-work.outputs.issue_number }}" (DO NOT use "Fixes #" - issues are closed after deploy)
             - Enable auto-merge: gh pr merge --auto --squash (this merges automatically when CI passes)
 
             ## Testing Requirements

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -344,16 +344,19 @@ Background automation handles issue triage and work without manual intervention.
 1. User reports bug via "Report a Bug" button → Creates P3 issue
 2. Triage workflow runs → Assigns P0/P1/P2 label with comment
 3. Work workflow triggers immediately (event-driven by label)
-4. Claude implements fix → Creates PR with `Fixes #N` + enables auto-merge
+4. Claude implements fix → Creates PR with `Relates to #N` + enables auto-merge
 5. CI/CD runs on PR
 6. **If CI/CD fails**: CI/CD Fix workflow triggers
    - Analyzes failure logs
    - Commits fix with `Fix CI/CD: <description>` message
    - CI/CD reruns automatically
    - Repeats up to 15 times until green or escalates to human
-7. CI/CD passes → PR merged → Issue auto-closes
-8. Work workflow self-chains → Picks up next issue if any
-9. Cycle continues until no P0-P2 issues remain
+7. CI/CD passes → PR merged → **Deployment runs**
+8. **After successful deploy + smoke tests**: Issues are auto-closed with deploy confirmation
+9. Work workflow self-chains → Picks up next issue if any
+10. Cycle continues until no P0-P2 issues remain
+
+**Important**: Issues are NOT closed on PR merge. They are only closed after successful deployment to production. This ensures users don't see "fixed" issues that haven't actually been deployed.
 
 ### Manual Trigger
 


### PR DESCRIPTION
## Summary
- Change PR body from "Fixes #N" to "Relates to #N" (prevents auto-close on merge)
- Add close-issues job that runs after successful deploy + smoke tests
- Issues now closed with deploy confirmation comment
- Update CLAUDE.md documentation

## Problem
Issues were auto-closed when PR merged, but CI could fail on main, blocking deploy. Users saw "fixed" issues that were never deployed.

## Solution
Issues only close after:
1. PR merges
2. Main CI passes
3. Docker images built
4. Railway deploy succeeds
5. Smoke tests pass