### PR TITLE
Add version number (triggers deploy for pending fixes)

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,1 +1,3 @@
 """Thinkers Chat Backend API."""
+
+__version__ = "0.1.0"


### PR DESCRIPTION
## Summary
Adds `__version__` to backend to trigger a full CI run with deploy.

## Why
Several user-facing fixes are stuck in main but never deployed:
- #188: iOS header sticky fix
- #191: Thinkers using display names

The code is on main, but earlier CI failures prevented deploy.
This triggers a fresh build and deploy.