### PR TITLE
Document and enhance reopened issue handling

### DIFF
--- a/.github/workflows/claude-work.yml
+++ b/.github/workflows/claude-work.yml
@@ -253,13 +253,22 @@ jobs:
           prompt: |
             You are working on issue #${{ needs.find-work.outputs.issue_number }}: ${{ needs.find-work.outputs.issue_title }}
 
+            ## ⚠️ REOPENED ISSUE CHECK
+            ${{ github.event.action == 'reopened' && '**THIS IS A REOPENED ISSUE.** The previous fix did NOT work in production. You MUST:
+            1. Review the issue comments to understand what was tried before
+            2. Check the git history for the previous fix attempt
+            3. Understand WHY the previous fix failed in production
+            4. Take a DIFFERENT approach - do not repeat the same fix
+            5. Be more thorough with testing and verification' || 'This is a new issue (not reopened).' }}
+
             ## Instructions
             1. Read CLAUDE.md for project context and coding standards
             2. Read the full issue details with: gh issue view ${{ needs.find-work.outputs.issue_number }}
-            3. Understand the codebase structure
-            4. Implement the required changes
-            5. Run tests to verify your changes work
-            6. Create a PR with your changes
+            3. **Review issue comments** for context on previous attempts (especially for reopened issues)
+            4. Understand the codebase structure
+            5. Implement the required changes
+            6. Run tests to verify your changes work
+            7. Create a PR with your changes
 
             ## Development Workflow
             - Create a branch: git checkout -b claude/issue-${{ needs.find-work.outputs.issue_number }}-${{ github.run_id }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -325,6 +325,7 @@ Background automation handles issue triage and work without manual intervention.
 
 **Automated Work** (`.github/workflows/claude-work.yml`):
 - **Event-driven**: Triggers immediately when issues get P0/P1/P2 labels
+- **Reopened issues**: Triggers when issues are reopened (fix didn't work in production)
 - **Self-chaining**: Uses `repository_dispatch` to continue processing queue
 - **Fallback**: Scheduled every 6 hours to catch edge cases
 - Finds highest priority open issue (P0 → P1 → P2)
@@ -334,6 +335,13 @@ Background automation handles issue triage and work without manual intervention.
 - PRs merge automatically when CI passes (no manual intervention needed)
 - Removes `claude-working` label when done (on success only - failed issues keep label)
 - Concurrency control: only one work job runs at a time (others queue)
+
+**Reopened Issue Handling**:
+When an issue is reopened, it means the previous fix didn't actually work in production. The workflow:
+1. Triggers automatically on the `reopened` event
+2. Removes `in-review` label (from the failed fix attempt)
+3. Works on that specific issue directly
+4. Claude is instructed to understand this is a RETRY - the original fix failed in production
 
 **CI/CD Fix Loop** (`.github/workflows/claude-cicd-fix.yml`):
 - **Triggers**: When CI/CD fails on a PR created by `claude[bot]`


### PR DESCRIPTION
## Summary
- Document reopened issue workflow in CLAUDE.md
- Add dynamic prompt section that warns Claude when working on reopened issues
- Instruct Claude to review previous attempts and take a different approach

## Changes
1. **CLAUDE.md**: Added "Reopened Issue Handling" section explaining the workflow
2. **claude-work.yml**: Added conditional prompt section that:
   - Detects when working on a reopened issue
   - Warns Claude the previous fix didn't work in production
   - Instructs Claude to review previous attempts and take a different approach

## Test plan
- [ ] Verify workflow still triggers correctly on priority labels
- [ ] Close and reopen an issue to verify the prompt includes the reopened warning
- [ ] Verify new issues show "This is a new issue (not reopened)"