### PR TITLE
Move Dijkstra avatar to right of Thinkers Chat title

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -77,6 +77,7 @@ export function Sidebar({
                 rel="noopener noreferrer"
                 className="flex items-center gap-2 text-lg font-bold text-zinc-900 dark:text-zinc-100 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
               >
+                Thinkers Chat
                 <Image
                   src="/icon.png"
                   alt="Dijkstra"
@@ -84,7 +85,6 @@ export function Sidebar({
                   height={32}
                   className="rounded-full"
                 />
-                Thinkers Chat
               </a>
               <button
                 onClick={onToggle}


### PR DESCRIPTION
Moves Dijkstra's avatar from the left to the right of the "Thinkers Chat" title in the sidebar header.

Relates to #231