### PR TITLE
Fix: Disable track_progress for reopened issues

### DIFF
--- a/.github/workflows/claude-work.yml
+++ b/.github/workflows/claude-work.yml
@@ -251,7 +251,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ github.token }}
-          track_progress: ${{ github.event_name == 'issues' }}  # Only supported for issue events
+          track_progress: ${{ github.event_name == 'issues' && github.event.action != 'reopened' }}  # Not supported for 'reopened' action
           allowed_bots: '*'  # Allow self-chaining via repository_dispatch
           prompt: |
             You are working on issue #${{ needs.find-work.outputs.issue_number }}: ${{ needs.find-work.outputs.issue_title }}


### PR DESCRIPTION
## Summary

The `claude-code-action` doesn't support `reopened` as an issue action type when `track_progress` is enabled, causing:
```
Error: Unsupported issue action: reopened
```

This was discovered when testing the workflow on issue #234 after reopening it.

## Fix

Changed:
```yaml
track_progress: ${{ github.event_name == 'issues' }}
```

To:
```yaml
track_progress: ${{ github.event_name == 'issues' && github.event.action != 'reopened' }}
```

## Test plan
- [ ] Reopen issue #234 after merging this PR
- [ ] Verify workflow runs successfully
- [ ] Verify PR is created automatically (from previous fix)

Relates to #234