### PR TITLE
Fix: Add workflow_dispatch to CI for manual deployments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:  # Allow manual triggering for deployments
 
 env:
   REGISTRY: ghcr.io
@@ -39,7 +40,7 @@ jobs:
     name: Backend Tests
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.backend == 'true'
+    if: needs.changes.outputs.backend == 'true' || github.event_name == 'workflow_dispatch'
     defaults:
       run:
         working-directory: backend
@@ -72,7 +73,7 @@ jobs:
     name: Frontend Tests
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.frontend == 'true'
+    if: needs.changes.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch'
     defaults:
       run:
         working-directory: frontend
@@ -167,8 +168,8 @@ jobs:
     if: |
       always() &&
       github.ref == 'refs/heads/main' &&
-      github.event_name == 'push' &&
-      needs.changes.outputs.e2e == 'true' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
+      (needs.changes.outputs.e2e == 'true' || github.event_name == 'workflow_dispatch') &&
       needs.backend.result != 'failure' &&
       needs.frontend.result != 'failure'
     permissions:
@@ -244,7 +245,7 @@ jobs:
       always() &&
       needs.build-and-push.result == 'success' &&
       github.ref == 'refs/heads/main' &&
-      github.event_name == 'push'
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
 
     steps:
       - name: Install Railway CLI
@@ -269,7 +270,7 @@ jobs:
       always() &&
       needs.deploy.result == 'success' &&
       github.ref == 'refs/heads/main' &&
-      github.event_name == 'push'
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
 
     steps:
       - name: Wait for deployment to stabilize
@@ -379,7 +380,7 @@ jobs:
       always() &&
       needs.smoke-test.result == 'success' &&
       github.ref == 'refs/heads/main' &&
-      github.event_name == 'push'
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     permissions:
       issues: write
 


### PR DESCRIPTION
## Summary

When PRs auto-merge quickly (like PR #237), the push event may not trigger CI, leaving code changes undeployed. This was why the Dijkstra avatar fix was in main but never deployed to production.

### Changes
1. Added `workflow_dispatch` trigger to CI workflow
2. Updated all job conditions to run when manually triggered:
   - Backend tests
   - Frontend tests
   - Build & push
   - Deploy
   - Smoke test
   - Close related issues

### Usage
After merging this PR, if a deploy is missed, run:
```bash
gh workflow run ci.yml --repo jeremymatthewwerner/thinkers-chat --ref main
```

## Test plan
- [ ] Merge this PR
- [ ] Manually trigger CI to deploy pending changes
- [ ] Verify Dijkstra avatar is on left in production
- [ ] Issue #240 should auto-close

Relates to #240