### PR TITLE
Fix: Trigger CI via repository_dispatch after auto-merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:  # Allow manual triggering for deployments
+  repository_dispatch:  # Triggered by claude-work after auto-merge (GITHUB_TOKEN can't trigger push)
+    types: [deploy-after-merge]
 
 env:
   REGISTRY: ghcr.io
@@ -40,7 +42,7 @@ jobs:
     name: Backend Tests
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.backend == 'true' || github.event_name == 'workflow_dispatch'
+    if: needs.changes.outputs.backend == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch'
     defaults:
       run:
         working-directory: backend
@@ -73,7 +75,7 @@ jobs:
     name: Frontend Tests
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch'
+    if: needs.changes.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch'
     defaults:
       run:
         working-directory: frontend
@@ -168,8 +170,8 @@ jobs:
     if: |
       always() &&
       github.ref == 'refs/heads/main' &&
-      (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
-      (needs.changes.outputs.e2e == 'true' || github.event_name == 'workflow_dispatch') &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch') &&
+      (needs.changes.outputs.e2e == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch') &&
       needs.backend.result != 'failure' &&
       needs.frontend.result != 'failure'
     permissions:
@@ -245,7 +247,7 @@ jobs:
       always() &&
       needs.build-and-push.result == 'success' &&
       github.ref == 'refs/heads/main' &&
-      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch')
 
     steps:
       - name: Install Railway CLI
@@ -270,7 +272,7 @@ jobs:
       always() &&
       needs.deploy.result == 'success' &&
       github.ref == 'refs/heads/main' &&
-      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch')
 
     steps:
       - name: Wait for deployment to stabilize
@@ -380,7 +382,7 @@ jobs:
       always() &&
       needs.smoke-test.result == 'success' &&
       github.ref == 'refs/heads/main' &&
-      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch')
     permissions:
       issues: write
 

--- a/.github/workflows/claude-work.yml
+++ b/.github/workflows/claude-work.yml
@@ -404,6 +404,23 @@ jobs:
             --remove-label "claude-working" \
             --add-label "in-review" || true
 
+      - name: Trigger CI after auto-merge
+        # GITHUB_TOKEN merges can't trigger push events, so we manually trigger CI
+        # This ensures code gets deployed after auto-merge completes
+        if: success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "Waiting for auto-merge to complete..."
+          sleep 30  # Give time for PR to merge
+
+          echo "Triggering CI/CD pipeline..."
+          gh api repos/${{ github.repository }}/dispatches \
+            -f event_type=deploy-after-merge \
+            -f 'client_payload[issue_number]=${{ needs.find-work.outputs.issue_number }}'
+
+          echo "CI triggered. Deploy will close issue after success."
+
   # Self-chain: trigger another run if there's more work
   # Runs on always() so failures don't stop the queue - other issues still get processed
   # Failed issues get needs-human-help label, successful issues get in-review label


### PR DESCRIPTION
## Summary

Fixes the root cause of why PRs were merging but code never deployed.

### Problem
GitHub Actions prevents `GITHUB_TOKEN` operations from triggering other workflows to avoid infinite loops. When the Claude work workflow auto-merges PRs using `GITHUB_TOKEN`, the push event doesn't trigger CI.

> "When you use the repository's GITHUB_TOKEN to perform tasks, events triggered by the GITHUB_TOKEN will not create a new workflow run."
> — [GitHub Docs](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow)

### Solution
1. Added `repository_dispatch` trigger (`deploy-after-merge`) to CI workflow
2. Added step in claude-work.yml to trigger CI after auto-merge completes
3. Updated all CI job conditions to handle `repository_dispatch`

### How it works
```
Claude creates PR → Auto-merge → Wait 30s → Dispatch deploy-after-merge → CI runs → Deploy
```

## Test plan
- [ ] Merge this PR
- [ ] File a new trivial issue
- [ ] Verify automation: issue → work → PR → merge → CI triggers → deploy → issue closes

Sources:
- https://github.com/orgs/community/discussions/25702
- https://docs.github.com/en/actions/using-workflows/triggering-a-workflow